### PR TITLE
feat: improve formatting of code owners list

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       {
         "id": "codeOwnership.file",
         "actionItem": {
-          "label": "Owner: ${get(context, `codeOwnership.file.${resource.uri}`)}"
+          "label": "${get(context, `codeOwnership.file.${resource.uri}.label`)}",
+          "description": "${get(context, `codeOwnership.file.${resource.uri}.description`)}"
         }
       }
     ],
@@ -46,7 +47,7 @@
       "editor/title": [
         {
           "action": "codeOwnership.file",
-          "when": "!config.codeOwnership.hide && get(context, `codeOwnership.file.${resource.uri}`)"
+          "when": "!config.codeOwnership.hide && get(context, `codeOwnership.file.${resource.uri}.label`)"
         }
       ],
       "commandPalette": [

--- a/src/codeOwners.test.ts
+++ b/src/codeOwners.test.ts
@@ -1,0 +1,20 @@
+import expect from 'expect'
+import { formatCodeOwners } from './codeOwners'
+
+describe('formatCodeOwners', () => {
+    it('formats null', () => expect(formatCodeOwners(null)).toEqual({ label: null, description: null }))
+    it('formats empty', () =>
+        expect(formatCodeOwners([])).toEqual({ label: 'No owner', description: 'File has no code owner' }))
+    it('formats 1', () =>
+        expect(formatCodeOwners(['alice'])).toEqual({ label: 'Owner: alice', description: 'Code owner: alice' }))
+    it('formats 1 with long name', () =>
+        expect(formatCodeOwners(['alice-long-name'])).toEqual({
+            label: 'Owner',
+            description: 'Code owner: alice-long-name',
+        }))
+    it('formats 2', () =>
+        expect(formatCodeOwners(['alice', 'bob'])).toEqual({
+            label: '2 owners',
+            description: 'Code owners: alice, bob',
+        }))
+})

--- a/src/codeOwners.ts
+++ b/src/codeOwners.ts
@@ -1,0 +1,21 @@
+const SHOW_SINGLE_OWNER_MAX_LENGTH = 14
+
+export function formatCodeOwners(owners: string[] | null): { label: string | null; description: string | null } {
+    if (owners === null) {
+        return { label: null, description: null }
+    }
+    if (owners.length === 0) {
+        return { label: 'No owner', description: 'File has no code owner' }
+    }
+    if (owners.length === 1) {
+        const owner = owners[0]
+        return {
+            label: owner.length <= SHOW_SINGLE_OWNER_MAX_LENGTH ? `Owner: ${owners[0]}` : 'Owner',
+            description: `Code owner: ${owner}`,
+        }
+    }
+    return {
+        label: `${owners.length} owners`,
+        description: `Code owners: ${owners.join(', ')}`,
+    }
+}

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,3 +1,0 @@
-describe('extension', () => {
-    it('works', () => void 0)
-})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import { combineLatest, from, Observable } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { getCodeOwners } from './codeownersFile'
+import { formatCodeOwners } from './codeOwners'
 
 export function activate(ctx: sourcegraph.ExtensionContext): void {
     ctx.subscriptions.add(
@@ -27,8 +28,10 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                     console.error(`Error getting code owners for ${doc.uri}:`, err)
                 }
             }
+            const { label, description } = formatCodeOwners(owners)
             sourcegraph.internal.updateContext({
-                [`codeOwnership.file.${doc.uri}`]: owners && owners.length > 0 ? owners.join(', ') : null,
+                [`codeOwnership.file.${doc.uri}.label`]: label,
+                [`codeOwnership.file.${doc.uri}.description`]: description,
             })
         })
     )


### PR DESCRIPTION
Long owners lists make the file header item very long and may cause other items to wrap. Fix this by aggressively truncating the item label and showing the full list in the tooltip.