### PR TITLE
feat: make action item jump to matching line

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       },
       {
         "id": "codeOwnership.file",
+        "command": "open",
+        "commandArguments": [
+          "${get(context, `codeOwnership.file.${resource.uri}.url`)}"
+        ],
         "actionItem": {
           "label": "${get(context, `codeOwnership.file.${resource.uri}.label`)}",
           "description": "${get(context, `codeOwnership.file.${resource.uri}.description`)}"

--- a/src/codeOwners.ts
+++ b/src/codeOwners.ts
@@ -1,7 +1,9 @@
 const SHOW_SINGLE_OWNER_MAX_LENGTH = 14
 
-export function formatCodeOwners(owners: string[] | null): { label: string | null; description: string | null } {
-    if (owners === null) {
+export function formatCodeOwners(
+    owners: string[] | null | undefined
+): { label: string | null; description: string | null } {
+    if (!owners) {
         return { label: null, description: null }
     }
     if (owners.length === 0) {

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -6,9 +6,9 @@ export function resolveURI(uri: string): { repo: string; rev: string; path: stri
     const url = new URL(uri)
     if (url.protocol === 'git:') {
         return {
-            repo: (url.host + url.pathname).replace(/^\/*/, '').toLowerCase(),
-            rev: url.search.slice(1).toLowerCase(),
-            path: url.hash.slice(1),
+            repo: decodeURIComponent((url.host + url.pathname).replace(/^\/*/, '').toLowerCase()),
+            rev: decodeURIComponent(url.search.slice(1).toLowerCase()),
+            path: decodeURIComponent(url.hash.slice(1)),
         }
     }
     throw new Error(`unrecognized URI: ${JSON.stringify(uri)} (supported URI schemes: git)`)


### PR DESCRIPTION
Action items withou a command are not valid according to our schema and cause user confusion (https://github.com/sourcegraph/sourcegraph/issues/5488). This gives the action item a valid purpose: Jumping to the resolved code owner file at the exact line of the resolved pattern.